### PR TITLE
Remove possibility of race condition during build

### DIFF
--- a/rules/private/list_repository_tools_srcs.go
+++ b/rules/private/list_repository_tools_srcs.go
@@ -90,8 +90,15 @@ func main() {
 	fmt.Fprintln(buf, "]")
 
 	if *generate != "" {
-		if err := ioutil.WriteFile(*generate, buf.Bytes(), 0666); err != nil {
+		got, err := ioutil.ReadFile(*generate)
+		if err != nil {
 			log.Fatal(err)
+		}
+
+		if !bytes.Equal(got, buf.Bytes()) {
+			if err := ioutil.WriteFile(*generate, buf.Bytes(), 0666); err != nil {
+				log.Fatal(err)
+			}
 		}
 	} else {
 		got, err := ioutil.ReadFile(*check)


### PR DESCRIPTION
It seems plausible that re-writing one of Bazel's input files during the build could be causing the weird syntax error issue we are seeing, maybe due to a race condition on this file being read from and written to at the same time.

This doesn't overwrite the file if it's already up to date.